### PR TITLE
Fix duplicate edges in attack graphs

### DIFF
--- a/ag_generation.py
+++ b/ag_generation.py
@@ -264,6 +264,7 @@ def make_attack_graphs(state_sequences, sev_sinks, datafile, dir_name, save_ag=T
             # -----------------------------------------------------------------
             node_signatures = {}         # vname -> set(str)
             already_addressed = set()    # 已 dotted 的 sink label
+            seen_edges = set()
 
             for team_att, attempts in team_attempts.items():
                 color = tcols[team_att.split('-')[0]]
@@ -293,7 +294,10 @@ def make_attack_graphs(state_sequences, sev_sinks, datafile, dir_name, save_ag=T
                         edge_line = _create_edge_line(
                             idx, v1, v2, ts1, ts2, color, team_att.split('-')[1]
                         )
-                        lines.append((t1, edge_line))
+                        key = (v1, v2, team_att.split('-')[1])
+                        if key not in seen_edges:
+                            lines.append((t1, edge_line))
+                            seen_edges.add(key)
 
             # --------- 針對所有節點補 shape、tooltip ---------
             for vname, sigset in node_signatures.items():

--- a/tests.py
+++ b/tests.py
@@ -108,6 +108,49 @@ expected = [(0, 1), (6, 8), (15, 17), (196, 197)]
 run_episode_test(y, expected, "Test case 14: ramp up at end")
 
 
+def run_duplicate_edges_test():
+    global passed_tests
+    global total_tests
+
+    print("Running test \"Duplicate edges removed\"")
+
+    from datetime import datetime
+    import os
+    from ag_generation import make_attack_graphs
+
+    state_sequences = {
+        't0-1.1.1.1->2.2.2.2': [
+            (0, 1, 20, 1, 'http', {'sig'}, (datetime(2020, 1, 1, 0, 0), datetime(2020, 1, 1, 0, 1))),
+            (1, 2, 21, 2, 'http', {'sig'}, (datetime(2020, 1, 1, 0, 1), datetime(2020, 1, 1, 0, 2))),
+            (2, 3, 110, 3, 'http', {'sig'}, (datetime(2020, 1, 1, 0, 2), datetime(2020, 1, 1, 0, 3))),
+            (100, 101, 20, 4, 'http', {'sig'}, (datetime(2020, 1, 1, 1, 0), datetime(2020, 1, 1, 1, 1))),
+            (101, 102, 21, 5, 'http', {'sig'}, (datetime(2020, 1, 1, 1, 1), datetime(2020, 1, 1, 1, 2))),
+            (102, 103, 110, 6, 'http', {'sig'}, (datetime(2020, 1, 1, 1, 2), datetime(2020, 1, 1, 1, 3))),
+        ]
+    }
+
+    os.makedirs('ag_test_output', exist_ok=True)
+    orig_system = os.system
+    os.system = lambda cmd: 0
+    make_attack_graphs(state_sequences, set(), 'testdata', 'ag_test_output', save_ag=True)
+    os.system = orig_system
+
+    dot_path = 'ag_test_output/testdata-attack-graph-for-victim-2.2.2.2-DATADELIVERYhttp.dot'
+    with open(dot_path) as fh:
+        lines = fh.readlines()
+    edge_lines = [l for l in lines if 'color=maroon' in l and '->' in l]
+
+    if len(edge_lines) == 2:
+        print('Pass')
+        passed_tests += 1
+    else:
+        print(f'Fail: expected 2 edges but found {len(edge_lines)}')
+    total_tests += 1
+
+
+run_duplicate_edges_test()
+
+
 print(f"Tests passed {passed_tests }/{total_tests}")
 
 if passed_tests != total_tests:


### PR DESCRIPTION
## Summary
- deduplicate edges when rendering attack graphs
- add regression test ensuring repeated attempts don't create duplicate edges

## Testing
- `python tests.py` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686159bcba388326812ebcb6ec2d8a15