### PR TITLE
Handle invalid state ID

### DIFF
--- a/ag_generation.py
+++ b/ag_generation.py
@@ -9,7 +9,8 @@ def _translate(label, root=False):
 
     @param label: the label of the node (`mcat|mserv` or `mcat|mserv|state_ID`, where `mcat` is a string mapped from the `micro` dictionary, e.g. `DATA_DELIVERY|http|36`)
     @param root: whether this node is a root node (will be prepended with 'Victim: <victim_ip>\n')
-    @return: a new more human-readable version of the label
+    @return: a new more human-readable version of the label. The state ID is
+        appended only when it is not "-1".
     """
     new_label = ""
     parts = label.split("|")
@@ -23,7 +24,7 @@ def _translate(label, root=False):
             new_label += "\n" + parts[1].upper()
         else:
             new_label += "\n" + parts[1]
-    if len(parts) >= 3:
+    if len(parts) >= 3 and parts[2] != '-1':
         new_label += " | ID: " + parts[2]
 
     return new_label

--- a/test-scripts/diff-edges.sh
+++ b/test-scripts/diff-edges.sh
@@ -57,7 +57,7 @@ fi
 # Put the name of the edge (i.e. "src->dst") next to the label of the edge (time metadata), separated by a "#"
 parse_edges(){
     # Format of an edge with an attacker label after executing the `gvpr` script
-    # ARBITRARY CODE EXECUTION|ftp | ID: -1->ROOT PRIVILEGE ESCALATION|ms-wbt-server | ID: -1	<font color="magenta"> start_next: 04/11/17, 17:47:40<br/>gap: 4373sec<br/>end_prev: 04/11/17, 16:34:47</font><br/><font color="magenta"><b>Attacker: 10.0.254.31</b></font>
+    # ARBITRARY CODE EXECUTION|ftp -> ROOT PRIVILEGE ESCALATION|ms-wbt-server | ID: 42	<font color="magenta"> start_next: 04/11/17, 17:47:40<br/>gap: 4373sec<br/>end_prev: 04/11/17, 16:34:47</font><br/><font color="magenta"><b>Attacker: 10.0.254.31</b></font>
     edges=$(gvpr '
         E [$.label == ""] { print(gsub(gsub($.name, "\r"), "\n", " | ")); }     // For edges without labels, simply print their names
         E [$.label != "" ] {                                                    // For edges with labels, print their names and labels


### PR DESCRIPTION
## Summary
- don't show `ID: -1` when translating attack graph node labels
- update example output in `diff-edges.sh`

## Testing
- `python tests.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6861649c1c1c83269b4380999666fa41